### PR TITLE
add `no_cursor_timeout` to `mongo.find`

### DIFF
--- a/cloud_utils/cache/mongo.py
+++ b/cloud_utils/cache/mongo.py
@@ -24,7 +24,7 @@ def aggregate(
 def find(
     query: Dict[Text, Any], collection: pymongo.collection.Collection,
 ) -> Tuple[Dict, ...]:
-    return collection.find(query)
+    return collection.find(query, no_cursor_timeout=True)
 
 
 find_all = find({})


### PR DESCRIPTION
When running queries in `analysis` that retrieve a big number of convos we're getting the error
```
pymongo.errors.CursorNotFound: Cursor not found
```

Adding this flag as advised here: https://www.programmersought.com/article/5325272332/
Tell me wdyt