### PR TITLE
CORE-34: flush pickle cache on exit so the sub-threshold tail persists

### DIFF
--- a/cloud_utils/cache/stores/pickle.py
+++ b/cloud_utils/cache/stores/pickle.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 import os
 import pickle
@@ -67,6 +68,20 @@ def make_store(cache_path: str, name: str) -> Tuple[Callable, Callable]:
                 logging.error(
                     f"Could not sync {name} with local file. Error: {exception}.",
                 )
+
+    def flush_on_exit():
+        # The periodic sync above leaves the last `change_count` (< threshold) writes
+        # unpersisted; flush them once at shutdown so the on-disk cache is complete.
+        if change_count == 0:
+            return
+        try:
+            _save_cache_locally(name, cache_path, cache)
+        except (OSError, IOError, EOFError) as exception:
+            logging.error(
+                f"Could not flush {name} to local file on exit. Error: {exception}.",
+            )
+
+    atexit.register(flush_on_exit)
 
     return get_item, set_item
 

--- a/cloud_utils/cache/stores/pickle_test.py
+++ b/cloud_utils/cache/stores/pickle_test.py
@@ -1,4 +1,29 @@
+import os
+import pickle as stdlib_pickle
+import subprocess
+import sys
+
 from cloud_utils.cache.stores import pickle
+
+
+def test_pickle_store_flushes_sub_threshold_writes_on_exit(tmp_path):
+    # A handful of writes never reaches the periodic-sync threshold, so without the
+    # exit flush the on-disk cache is never written. A clean process exit must still
+    # persist all of them.
+    keys = 3
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from cloud_utils.cache.stores import pickle;"
+            f"_, set_item = pickle.make_store({str(tmp_path)!r}, 'exit-store');"
+            f"[set_item(str(i), i) for i in range({keys})]",
+        ],
+        check=True,
+        env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+    )
+    with open(tmp_path / "exit-store.pickle", "rb") as cache_file:
+        assert len(stdlib_pickle.load(cache_file)) == keys
 
 
 def test_pickle_store(pickle_file):


### PR DESCRIPTION
## Summary
The pickle store (`cloud_utils/cache/stores/pickle.py`) syncs to disk only every 50 changed keys and never flushes on exit, so the last `keys mod 50` writes of a process are lost. A consumer that writes fewer than 50 keys (or has a non-divisible tail) leaves the on-disk cache incomplete and re-fetches that tail on every subsequent run.

Concretely (nlu-runtime Langfuse prompt cache, 79 prompts): a cold import fetches 79 but persists only 50; every later process re-fetches the same ~29-prompt tail forever, because 29 < 50 never triggers a sync.

Fix: register a guarded `atexit` flush in `make_store` that does one final `_save_cache_locally` when there are unsynced changes (`change_count > 0`). The 50-key periodic sync stays (bounds loss on a hard crash); the flush is a no-op for read-only usage (`change_count` stays 0), off the hot path (shutdown only), and exception-guarded for read-only filesystems.
