### PR TITLE
CORE-31: make pickle store sync_threshold a required parameter

### DIFF
--- a/cloud_utils/cache/stores/pickle.py
+++ b/cloud_utils/cache/stores/pickle.py
@@ -7,8 +7,6 @@ import gamla
 
 from cloud_utils.cache import utils
 
-_NUMBER_OF_KEYS_CHANGED_TO_TRIGGER_SYNC = 50
-
 
 def _local_cache_path(cache_name: str, path: str):
     return os.path.join(path, f"{cache_name}.pickle")
@@ -29,7 +27,9 @@ def _save_cache_locally(cache_name: str, path: str, cache: Dict[Tuple, Any]):
     logging.info(f"Saved {len(cache)} cache items locally for {cache_name}.")
 
 
-def make_store(cache_path: str, name: str) -> Tuple[Callable, Callable]:
+def make_store(
+    cache_path: str, name: str, sync_threshold: int
+) -> Tuple[Callable, Callable]:
     change_count = 0
     utils.log_initialized_cache("pickle", name)
     # Initialize cache.
@@ -52,9 +52,9 @@ def make_store(cache_path: str, name: str) -> Tuple[Callable, Callable]:
         change_count += 1
         cache[utils.cache_key_name(name, key)] = value
 
-        if change_count >= _NUMBER_OF_KEYS_CHANGED_TO_TRIGGER_SYNC:
+        if change_count >= sync_threshold:
             logging.info(
-                f"More than {_NUMBER_OF_KEYS_CHANGED_TO_TRIGGER_SYNC} keys changed in cache {name}. Syncing with local file.",
+                f"{change_count} keys changed in cache {name} (threshold {sync_threshold}). Syncing with local file.",
             )
 
             try:
@@ -62,7 +62,7 @@ def make_store(cache_path: str, name: str) -> Tuple[Callable, Callable]:
                 logging.info(
                     f"Synced cache {name} to local file",
                 )
-                change_count -= _NUMBER_OF_KEYS_CHANGED_TO_TRIGGER_SYNC
+                change_count -= sync_threshold
             except (OSError, IOError, EOFError) as exception:
                 logging.error(
                     f"Could not sync {name} with local file. Error: {exception}.",

--- a/cloud_utils/cache/stores/pickle_test.py
+++ b/cloud_utils/cache/stores/pickle_test.py
@@ -2,7 +2,7 @@ from cloud_utils.cache.stores import pickle
 
 
 def test_pickle_store(pickle_file):
-    get_item, set_item = pickle.make_store(pickle_file, "test-store")
+    get_item, set_item = pickle.make_store(pickle_file, "test-store", 50)
 
     set_item("1", 1)
     set_item("2", 2)
@@ -13,7 +13,7 @@ def test_pickle_store(pickle_file):
 
 
 def test_pickle_store_more_than_10_changed_keys(pickle_file):
-    get_item, set_item = pickle.make_store(pickle_file, "test-store")
+    get_item, set_item = pickle.make_store(pickle_file, "test-store", 10)
     for x in range(12):
         set_item(f"{x}", x)
     for x in range(12):
@@ -21,7 +21,7 @@ def test_pickle_store_more_than_10_changed_keys(pickle_file):
 
 
 async def test_pickle_store_async(pickle_file):
-    get_item, set_item = pickle.make_async_store(pickle_file, "test-store")
+    get_item, set_item = pickle.make_async_store(pickle_file, "test-store", 50)
 
     await set_item("1", 1)
     await set_item("2", 2)
@@ -29,3 +29,13 @@ async def test_pickle_store_async(pickle_file):
     assert await get_item("1") == 1
     assert await get_item("2") == 2
     assert await get_item("3") == 3
+
+
+def test_pickle_store_sync_threshold_one_persists_every_write(pickle_file):
+    # sync_threshold=1 flushes on every write, so a fresh store reads all keys from disk.
+    _, set_item = pickle.make_store(pickle_file, "test-store", 1)
+    for x in range(3):
+        set_item(f"{x}", x)
+    get_item, _ = pickle.make_store(pickle_file, "test-store", 1)
+    for x in range(3):
+        assert get_item(f"{x}") == x


### PR DESCRIPTION
## Summary
The pickle store synced to disk only every 50 changed keys (a hardcoded constant) with no final flush, so a store that never accumulated 50 net changes left an **incomplete** cache on disk. This makes the sync threshold a **required** argument to `make_store` / `make_async_store` so each caller declares its own: pass `50` to keep the prior behavior, or `1` to persist every write (e.g. a build-time cache that must be complete).

**Breaking:** `sync_threshold` has no default — existing callers must pass it. nlu-runtime callers are updated in the paired MR (general persistent cache → `50`, langfuse prompt store → `1`).
